### PR TITLE
fix: add security-events permission for SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,10 @@ jobs:
     timeout-minutes: 20
     needs: detect-changes
     if: needs.detect-changes.outputs.should-run-docker == 'true'
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

After merging PR #3, the Docker Build & Security Scan job on master branch started failing with:
```
Error: Resource not accessible by integration
Warning: Resource not accessible by integration - https://docs.github.com/rest
```

## Root Cause

The `docker-build-security` job uses `github/codeql-action/upload-sarif@v3` to upload Trivy security scan results to GitHub Code Scanning. This action requires the `security-events: write` permission, which wasn't explicitly set.

While PR #3 passed all checks, the permissions issue only surfaced after merge to master because default workflow permissions differ between PR contexts and master branch runs.

## Solution

Added explicit permissions block to `docker-build-security` job:
```yaml
permissions:
  contents: read           # Checkout code
  security-events: write   # Upload SARIF to Code Scanning
  actions: read            # Workflow metadata
```

## References
- [GitHub SARIF Upload Documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github)
- [CodeQL Action Permissions](https://github.com/github/codeql-action#permissions)

## Testing
- ✅ All quality checks passed locally (format, lint, type-check)
- ✅ CI will verify Docker build and SARIF upload succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)