### PR TITLE
fix: use pnpm instead of npm in semantic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Semantic Release
         id: semantic


### PR DESCRIPTION
## Problem

Semantic release workflow failing on master after successful merges:

```
Error: Dependencies lock file is not found in /home/runner/work/csfrace-scrape-front/csfrace-scrape-front
Supported file patterns: package-lock.json, npm-shrinkwrap.json, yarn.lock
```

**Workflow run**: https://github.com/zachatkinson/csfrace-scrape-front/actions/runs/18234892477

## Root Cause

The semantic release workflow (`.github/workflows/release.yml`) was configured to use **npm**, but this project uses **pnpm** with `pnpm-lock.yaml`.

**Problematic configuration:**
```yaml
- name: Setup Node.js
  uses: actions/setup-node@v4
  with:
    node-version: ${{ env.NODE_VERSION }}
    cache: "npm"  # ❌ Looking for package-lock.json

- name: Install dependencies
  run: npm ci  # ❌ Can't find package-lock.json
```

## Solution

Updated release workflow to use pnpm (matching CI workflow):

```yaml
- name: Setup Node.js
  uses: actions/setup-node@v4
  with:
    node-version: ${{ env.NODE_VERSION }}
    # Removed cache: "npm"

- name: Setup pnpm
  uses: pnpm/action-setup@v4
  with:
    version: 9

- name: Install dependencies
  run: pnpm install --frozen-lockfile
```

## Testing

- ✅ Format: passed
- ✅ Lint: 0 errors, 0 warnings  
- ✅ Type-check: 0 errors, 0 warnings, 0 hints
- ✅ All quality checks passed locally

Next semantic release after merge will verify the fix works end-to-end.

## Related

This aligns the release workflow with the CI workflow (`.github/workflows/ci.yml`) which already uses pnpm successfully for all jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)