### PR TITLE
fix: remove invalid JSON escape sequence in .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -60,7 +60,7 @@
         "successComment": "🎉 This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
         "labels": ["released"],
         "releasedLabels": [
-          "released<%= nextRelease.channel ? ` on @\${nextRelease.channel}` : \"\" %> from <%= branch.name %>"
+          "released<%= nextRelease.channel ? ` on @${nextRelease.channel}` : \"\" %> from <%= branch.name %>"
         ]
       }
     ],


### PR DESCRIPTION
## Summary
Fixes semantic release failure caused by invalid JSON escape sequence in `.releaserc.json`.

## Problem
Semantic release was failing with:
```
JSONError: JSON Error in /home/runner/work/csfrace-scrape-front/csfrace-scrape-front/.releaserc.json: 
Bad escaped character in JSON at position 2292 while parsing
> 63 |           "released<%= nextRelease.channel ? ` on @\${nextRelease.channel}` : \"\" %> from <%= branch.name %>"
     |                                                     ^
```

## Root Cause
Line 63 contained `\${nextRelease.channel}` with invalid escape sequence `\$`. In JSON, `\$` is not a valid escape - dollar signs don't need escaping in JSON strings.

## Changes
- **File**: `.releaserc.json:63`
- **Before**: `\${nextRelease.channel}`
- **After**: `${nextRelease.channel}`

The EJS template variable syntax works correctly without the backslash - it's evaluated by semantic-release's template engine, not interpreted as a JSON escape sequence.

## Testing
- ✅ Quality pipeline passed (format → lint → type-check → format)
- ✅ JSON is now syntactically valid
- ✅ Will verify semantic release succeeds after merge

## Related
- Fixes semantic release failures on master after PR #5 merged
- Follows up on pnpm configuration fix in PR #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)