### PR TITLE
fix: upgrade semantic-release v23 → v24 for conventionalcommits v8 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 23
+          semantic_version: 24
           extra_plugins: |
             @semantic-release/changelog@6.0.3
             @semantic-release/git@10.0.1


### PR DESCRIPTION
## Summary
Upgrades semantic-release from v23 to v24 to fix compatibility with conventional-changelog-conventionalcommits v8.0.0.

## Problem
After fixing the JSON syntax error in PR #6, semantic release continued to fail with a different error:
```
RangeError: Invalid time value
at committerDate (conventional-changelog-writer/index.js:80:30)
```

## Root Cause
- We're using `semantic-release` v23 (in GitHub Actions workflow)
- We're using `conventional-changelog-conventionalcommits` v8.0.0 (in package.json)
- **These versions are incompatible** - v23 has date parsing bugs with conventionalcommits preset v8+

## Solution (Best Practice)
✅ **Upgrade semantic-release from v23 to v24** (latest stable)
- semantic-release v24 is fully compatible with conventional-changelog-conventionalcommits v8.0.0+
- Maintains all dependencies at latest stable versions
- Avoids downgrading any packages

❌ Alternative (not recommended): Downgrade conventional-changelog-conventionalcommits to v7.2.2

## Changes
**File**: `.github/workflows/release.yml:70`
- **Before**: `semantic_version: 23`
- **After**: `semantic_version: 24`

## References
- [conventional-changelog issue #1275](https://github.com/conventional-changelog/conventional-changelog/issues/1275)
- [semantic-release/release-notes-generator issue #660](https://github.com/semantic-release/release-notes-generator/issues/660)
- [semantic-release/semantic-release issue #3292](https://github.com/semantic-release/semantic-release/issues/3292)

## Testing
- ✅ Quality pipeline passed (format → lint → type-check)
- ✅ Will verify semantic release succeeds after merge

## Why We Didn't Have This Issue in Backend
Backend repository doesn't use semantic-release, so it didn't encounter this compatibility issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)