### PR TITLE
fix: Docker build configuration for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          target: production
+          build-args: |
+            NODE_ENV=production
 
       - name: Generate container attestation
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
## Summary
Fixes Docker build failures in semantic release workflow by aligning build configuration with the single-stage Dockerfile design.

## Problem
After PR #7 merged (semantic-release v24 upgrade), the semantic release workflow failed at the Docker build step:
```
ERROR: failed to build: failed to solve: target stage "production" could not be found
```

## Root Cause
The release workflow specified `target: production` expecting a multi-stage Dockerfile, but our Dockerfile uses a modern single-stage design with conditional logic based on `NODE_ENV`.

## Solution
- **Removed**: `target: production` (expects multi-stage Dockerfile with `AS production`)
- **Added**: `build-args: NODE_ENV=production` (matches single-stage design)

The Dockerfile already handles production builds using NODE_ENV conditionals:
```dockerfile
ARG NODE_ENV=production
ENV NODE_ENV=${NODE_ENV}

RUN if [ "$NODE_ENV" = "production" ]; then \
    pnpm install --frozen-lockfile --production=false && \
    pnpm run build && \
    pnpm prune --production; \
fi
```

## Changes
**File**: `.github/workflows/release.yml:117-118`
```diff
- target: production
+ build-args: |
+   NODE_ENV=production
```

## Testing
- ✅ Quality pipeline passed (format → lint → type-check)
- ✅ Docker build will use NODE_ENV=production as intended
- ✅ Maintains single-stage Dockerfile best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)