### PR TITLE
fix: Docker build configuration for single-stage Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
       version: v${{ needs.semantic-release.outputs.version }}
       dockerfile-path: ./Dockerfile
       build-context: .
-      build-target: production
 
   # Job 3: Notify orchestrator (DRY: Reusable workflow)
   notify-orchestrator:


### PR DESCRIPTION
## Summary
Fixes Docker build failures in semantic release workflow by removing the `build-target` parameter that doesn't match the frontend's single-stage Dockerfile design.

## Problem
After PR #13 merged (CI/CD refactor), the semantic release workflow failed during Docker build:
```
ERROR: failed to build: failed to solve: target stage "production" could not be found
```

## Root Cause
The frontend release workflow was passing `build-target: production` to the reusable Docker publish workflow, but the frontend Dockerfile (on master branch) uses a **single-stage design** with `NODE_ENV` conditionals, NOT a multi-stage build with named stages like `AS production`.

## Solution
- **Removed**: `build-target: production` parameter from `docker-publish` job
- **Reason**: Frontend Dockerfile doesn't have named build stages
- **Impact**: Docker will build the entire Dockerfile (default behavior)

## Backend Comparison
The backend Dockerfile uses multi-stage build with explicit `AS builder` and `AS production` stages, so it correctly keeps `build-target: production` in its release workflow.

## Testing
- ✅ Orchestrator fix pushed: Removed default `build-target` value from reusable workflow
- ✅ Frontend workflow updated: Removed `build-target` parameter
- ✅ Backend workflow unchanged: Correctly uses `build-target: production` for multi-stage Dockerfile
- ✅ Next semantic release will use corrected configuration

## Files Changed
- `.github/workflows/release.yml` - Removed line 95: `build-target: production`

## Breaking Changes
None - this fixes existing broken functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>