### PR TITLE
fix: remove build-target parameter for flexible Dockerfile support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
       version: v${{ needs.semantic-release.outputs.version }}
       dockerfile-path: ./Dockerfile
       build-context: .
-      build-target: production
 
   # Job 3: Notify orchestrator (DRY: Reusable workflow)
   notify-orchestrator:


### PR DESCRIPTION
## Summary
Removes the `build-target: production` parameter from the Docker publish workflow to support the current single-stage Dockerfile design.

## Problem
The current workflow explicitly passes `build-target: production` to the reusable Docker publish workflow. This causes builds to fail because:
- Frontend Dockerfile uses a modern **single-stage design** with `NODE_ENV`-driven behavior
- Single-stage Dockerfiles have **no named stages**
- Passing `--target production` fails with "target stage 'production' could not be found"

## Solution
**Removed**: `build-target: production` parameter from `release.yml`

When no `--target` is specified, Docker's default behavior is:
- **Single-stage Dockerfile**: Builds the only stage ✅
- **Multi-stage Dockerfile**: Builds the final stage automatically

## Benefits
✅ **Fixes build failures**: Removes the cause of "target stage not found" errors
✅ **More flexible**: Works with any Dockerfile structure (single-stage or multi-stage)
✅ **Less coupling**: No need to coordinate stage names between Dockerfile and workflow
✅ **Docker best practice**: Leverages Docker's default behavior

## Changes
**File**: `.github/workflows/release.yml:95`
- **Removed**: `build-target: production`

## Current Frontend Dockerfile Structure
```dockerfile
# Single-stage with NODE_ENV-driven behavior
FROM node:20-alpine

ARG NODE_ENV=production
ENV NODE_ENV=${NODE_ENV}

# Install dependencies and build based on NODE_ENV
RUN if [ "$NODE_ENV" = "development" ]; then \
        pnpm install; \
    else \
        pnpm install && pnpm run build && pnpm prune --production; \
    fi

# CMD switches between dev/prod based on NODE_ENV
CMD ["sh", "-c", "if [ \"$NODE_ENV\" = \"development\" ]; then pnpm run dev; else pnpm run preview; fi"]
```

This modern single-stage design:
- Uses environment variables for behavior control
- More maintainable than multi-stage for simple apps
- Smaller and clearer than equivalent multi-stage approach

## Testing
✅ Frontend Dockerfile is single-stage (no named stages)
✅ Removing `--target` flag allows Docker to build the entire Dockerfile
✅ No functional change to resulting image
✅ Build will now succeed instead of failing

## Related
- **Backend PR**: Similar fix for backend repository
- **Root Cause**: Reusable workflow expected named stages that don't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>