### PR TITLE
fix: remove build-target parameter from Docker publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
       version: v${{ needs.semantic-release.outputs.version }}
       dockerfile-path: ./Dockerfile
       build-context: .
-      build-target: production
 
   # Job 3: Notify orchestrator (DRY: Reusable workflow)
   notify-orchestrator:


### PR DESCRIPTION
## Summary
Removes the deprecated `build-target` parameter from the frontend release workflow that was calling the reusable Docker publish workflow.

## Problem
The reusable Docker publish workflow's build-target parameter causes builds to fail when Dockerfiles don't have explicitly named stages matching the target.

## Solution
Removed `build-target: production` parameter from release.yml. The Docker build will now:
- Build the entire Dockerfile by default
- For single-stage Dockerfiles: builds the only stage
- For multi-stage Dockerfiles: builds the final stage automatically

## Benefits
- ✅ Works with both single-stage and multi-stage Dockerfiles
- ✅ No need to maintain consistency between workflow and Dockerfile stage names
- ✅ Follows Docker's default behavior (build final stage if no target specified)
- ✅ More flexible and less error-prone

## Quality Checks
- ✅ Prettier: All files unchanged
- ✅ ESLint: 0 warnings
- ✅ TypeScript: 0 errors/warnings/hints (197 files)

## Related PRs
- Orchestrator: https://github.com/zachatkinson/csfrace-scrape/pull/35
- Backend: https://github.com/zachatkinson/csfrace-scrape-back/pull/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>